### PR TITLE
remove apple-touch-icon link (causes vite errors)

### DIFF
--- a/giphy-search/index.html
+++ b/giphy-search/index.html
@@ -5,7 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
 
     <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">


### PR DESCRIPTION
The link tag containing `%PUBLIC_URL%/logo192.png` causes vite to show a `Url malformed` error on WSL and potentially other platforms. This PR removes it.